### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Cpreports/Form/Report/Cpreport.php
+++ b/CRM/Cpreports/Form/Report/Cpreport.php
@@ -567,7 +567,7 @@ class CRM_Cpreports_Form_Report_Cpreport extends CRM_Report_Form {
       // Get all the options for the Race field, so we can list them out.
       $allTextselectOptions = CRM_Textselect_Util::getAllFieldOptions();
       $raceOptions = [];
-      if ($raceTextselectOptions = CRM_Utils_Array::value($customFieldId_race, $allTextselectOptions)) {
+      if ($raceTextselectOptions = $allTextselectOptions[$customFieldId_race] ?? NULL) {
         foreach ($raceTextselectOptions as $raceTextselectOption) {
           $raceOptions[$raceTextselectOption['value']] = $raceTextselectOption['label'];
         }

--- a/CRM/Cpreports/Form/Report/Cpreport/Clientcarepartners.php
+++ b/CRM/Cpreports/Form/Report/Cpreport/Clientcarepartners.php
@@ -416,7 +416,7 @@ class CRM_Cpreports_Form_Report_Cpreport_Clientcarepartners extends CRM_Cpreport
     if (!empty(array_intersect_key($rows[0], array_flip($carePartnerColumnNames)))) {
       $prevContactId = '';
       foreach ($rows as &$row) {
-        $cid = CRM_Utils_Array::value('civicrm_contact_indiv_id', $row);
+        $cid = $row['civicrm_contact_indiv_id'] ?? NULL;
         if ($cid == $prevContactId) {
           foreach (array_keys($row) as $key) {
             if (!in_array(

--- a/CRM/Cpreports/Form/Report/Totalcontacthours.php
+++ b/CRM/Cpreports/Form/Report/Totalcontacthours.php
@@ -342,7 +342,7 @@ class CRM_Cpreports_Form_Report_Totalcontacthours extends CRM_Report_Form {
       // For each row, update the header totals for that sort_name.
       while ($dao->fetch()) {
         $sortName = $dao->civicrm_contact_assignee_sort_name;
-        if ($total = CRM_Utils_Array::value($sortName, $totals)) {
+        if ($total = $totals[$sortName] ?? NULL) {
           $total .= E::ts(" service records; total duration: %1", array(
             1 => $dao->ct,
           ));

--- a/CRM/Cpreports/Form/Report/clientcontacthours.php
+++ b/CRM/Cpreports/Form/Report/clientcontacthours.php
@@ -350,7 +350,7 @@ class CRM_Cpreports_Form_Report_clientcontacthours extends CRM_Report_Form {
       // For each row, update the header totals for that sort_name.
       while ($dao->fetch()) {
         $sortName = $dao->civicrm_contact_assignee_sort_name;
-        if ($total = CRM_Utils_Array::value($sortName, $totals)) {
+        if ($total = $totals[$sortName] ?? NULL) {
           $total .= E::ts(" service records; total duration: %1", array(
             1 => $dao->ct,
           ));


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.